### PR TITLE
Fix wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ colorscheme)</sup>
 Fall is a fuzzy finder for Vim and Neovim, implemented in [Denops], and stands
 for **"Filter All."**
 
-See [Features](./wiki/Features) for more information about Fall's features.
+See [Features](https://github.com/vim-fall/fall.vim/wiki/Features) for more information about Fall's features.
 
 > [!WARNING]
 >
@@ -78,7 +78,7 @@ Fall line README.md
 ![Fall Vim README Image](https://github.com/user-attachments/assets/4eb4db30-ee1e-458c-b619-765cf307a74c)
 
 Users can view available mappings by pressing `<F1>` in the picker window. See
-the [Mappings](./wiki/Mappings) page for more details.
+the [Mappings](https://github.com/vim-fall/fall.vim/wiki/Mappings) page for more details.
 
 ### Configuration
 
@@ -86,7 +86,7 @@ In Fall, settings that utilize Vim’s built-in functionality are categorized as
 “Configuration.” This includes key mappings, highlights, and buffer option
 modifications.
 
-Refer to the [Configuration](./wiki/Configuration) page on the GitHub Wiki for
+Refer to the [Configuration](https://github.com/vim-fall/fall.vim/wiki/Configuration) page on the GitHub Wiki for
 more details.
 
 ### Customization
@@ -96,7 +96,7 @@ categorized as “Customization.” These specifically refer to modifications ma
 to the user customization file, which can be accessed via the `FallCustom`
 command.
 
-Visit the [Customization](./wiki/Customization) page on the GitHub Wiki for more
+Visit the [Customization](https://github.com/vim-fall/fall.vim/wiki/Customization) page on the GitHub Wiki for more
 information.
 
 ## Related Projects


### PR DESCRIPTION
The wiki link in the README did not open with relative paths, so it was changed to an absolute path.