### PR TITLE
Do NOT check if corresponding mappings are already defined to define default mappings

### DIFF
--- a/denops/fall/picker.ts
+++ b/denops/fall/picker.ts
@@ -21,7 +21,10 @@ import { Scheduler } from "./lib/scheduler.ts";
 import { Cmdliner } from "./util/cmdliner.ts";
 import { isIncrementalMatcher } from "./util/predicate.ts";
 import { buildMappingHelpPages } from "./util/mapping.ts";
-import { emitPickerEnter, emitPickerLeave } from "./util/emitter.ts";
+import {
+  emitPickerEnterSystem,
+  emitPickerLeaveSystem,
+} from "./util/emitter.ts";
 import { CollectProcessor } from "./processor/collect.ts";
 import { MatchProcessor } from "./processor/match.ts";
 import { SortProcessor } from "./processor/sort.ts";
@@ -276,11 +279,11 @@ export class Picker<T extends Detail> implements AsyncDisposable {
       },
     );
 
-    // Emit 'FallPickerEnter/FallPickerLeave' autocmd
+    // Emit 'FallPickerEnterSystem/FallPickerLeaveSystem' autocmd
     stack.defer(async () => {
-      await emitPickerLeave(denops, this.#name);
+      await emitPickerLeaveSystem(denops, this.#name);
     });
-    await emitPickerEnter(denops, this.#name);
+    await emitPickerEnterSystem(denops, this.#name);
 
     return stack.move();
   }

--- a/denops/fall/util/emitter.ts
+++ b/denops/fall/util/emitter.ts
@@ -2,31 +2,33 @@ import type { Denops } from "jsr:@denops/std@^7.3.2";
 import { emit } from "jsr:@denops/std@^7.3.2/autocmd";
 
 /**
- * Save current cmap and emit `User FallPickerEnter:{name}` autocmd.
- *
- * The saved cmap will be restored by `emitPickerLeave`.
+ * Emit `User FallPickerEnterSystem:{name}` autocmd.
  */
-export async function emitPickerEnter(
+export async function emitPickerEnterSystem(
   denops: Denops,
   name: string,
 ): Promise<void> {
   try {
-    await emit(denops, "User", `FallPickerEnter:${name}`, { nomodeline: true });
+    await emit(denops, "User", `FallPickerEnterSystem:${name}`, {
+      nomodeline: true,
+    });
   } catch (err) {
-    console.warn(`[fall] Failed to emit FallPickerEnter:${name}`, err);
+    console.warn(`[fall] Failed to emit FallPickerEnterSystem:${name}`, err);
   }
 }
 
 /**
- * Restore saved cmap and emit `User FallPickerLeave:{name}` autocmd.
+ * Emit `User FallPickerLeaveSystem:{name}` autocmd.
  */
-export async function emitPickerLeave(
+export async function emitPickerLeaveSystem(
   denops: Denops,
   name: string,
 ): Promise<void> {
   try {
-    await emit(denops, "User", `FallPickerLeave:${name}`, { nomodeline: true });
+    await emit(denops, "User", `FallPickerLeaveSystem:${name}`, {
+      nomodeline: true,
+    });
   } catch (err) {
-    console.warn(`[fall] Failed to emit FallPickerLeave:${name}`, err);
+    console.warn(`[fall] Failed to emit FallPickerLeaveSystem:${name}`, err);
   }
 }

--- a/denops/fall/util/emitter_test.ts
+++ b/denops/fall/util/emitter_test.ts
@@ -1,10 +1,10 @@
 import { assertEquals } from "jsr:@std/assert@^1.0.6";
 import { DenopsStub } from "jsr:@denops/test@^3.0.4/stub";
 
-import { emitPickerEnter, emitPickerLeave } from "./emitter.ts";
+import { emitPickerEnterSystem, emitPickerLeaveSystem } from "./emitter.ts";
 
-Deno.test("emitPickerEnter", async (t) => {
-  await t.step("emit 'User FallPickerEnter:{name}'", async () => {
+Deno.test("emitPickerEnterSystem", async (t) => {
+  await t.step("emit 'User FallPickerEnterSystem:{name}'", async () => {
     const called: [string, Record<PropertyKey, unknown>][] = [];
     const denops = new DenopsStub({
       cmd(name, ctx): Promise<void> {
@@ -12,15 +12,15 @@ Deno.test("emitPickerEnter", async (t) => {
         return Promise.resolve();
       },
     });
-    await emitPickerEnter(denops, "test");
+    await emitPickerEnterSystem(denops, "test");
     assertEquals(called, [
-      ["do <nomodeline> User FallPickerEnter:test", {}],
+      ["do <nomodeline> User FallPickerEnterSystem:test", {}],
     ]);
   });
 });
 
-Deno.test("emitPickerLeave", async (t) => {
-  await t.step("emit 'User FallPickerLeave:{name}'", async () => {
+Deno.test("emitPickerLeaveSystem", async (t) => {
+  await t.step("emit 'User FallPickerLeaveSystem:{name}'", async () => {
     const called: [string, Record<PropertyKey, unknown>][] = [];
     const denops = new DenopsStub({
       cmd(name, ctx): Promise<void> {
@@ -28,9 +28,9 @@ Deno.test("emitPickerLeave", async (t) => {
         return Promise.resolve();
       },
     });
-    await emitPickerLeave(denops, "test");
+    await emitPickerLeaveSystem(denops, "test");
     assertEquals(called, [
-      ["do <nomodeline> User FallPickerLeave:test", {}],
+      ["do <nomodeline> User FallPickerLeaveSystem:test", {}],
     ]);
   });
 });

--- a/plugin/fall.vim
+++ b/plugin/fall.vim
@@ -11,6 +11,11 @@ command! -nargs=0 FallCustom call fall#command#FallCustom#call()
 command! -nargs=0 FallCustomReload call fall#command#FallCustomReload#call()
 command! -nargs=0 FallCustomRecache call fall#command#FallCustomRecache#call()
 
+function! s:bypass(event) abort
+  let l:name = matchstr(expand('<amatch>'), '^.\+:\zs.*$')
+  execute printf('doautocmd <nomodeline> User %s:%s', a:event, l:name)
+endfunction
+
 augroup fall_plugin
   autocmd! *
   autocmd User FallPickerEnter:* :
@@ -18,6 +23,8 @@ augroup fall_plugin
   autocmd User FallCustomLoaded :
   autocmd User FallCustomRecached :
   autocmd User FallPreviewRendered:* :
+  autocmd User FallPickerEnterSystem:* ++nested call s:bypass('FallPickerEnter')
+  autocmd User FallPickerLeaveSystem:* ++nested call s:bypass('FallPickerLeave')
 augroup END
 
 if !exists('g:fall_custom_path')
@@ -25,5 +32,3 @@ if !exists('g:fall_custom_path')
         \ ? expand(join([stdpath('config'), 'fall', 'custom.ts'], s:sep))
         \ : expand(join([$HOME, '.vim', 'fall', 'custom.ts'], s:sep))
 endif
-
-

--- a/plugin/fall/mapping.vim
+++ b/plugin/fall/mapping.vim
@@ -108,6 +108,6 @@ if !get(g:, 'fall_disable_default_mapping')
 
   augroup fall_mapping_plugin
     autocmd!
-    autocmd User FallPickerEnter:* call s:map_picker()
+    autocmd User FallPickerEnterSystem:* call s:map_picker()
   augroup END
 endif

--- a/plugin/fall/mapping.vim
+++ b/plugin/fall/mapping.vim
@@ -63,9 +63,7 @@ cnoremap <silent> <Plug>(fall-action-select) <Cmd>call fall#action('@select')<CR
 
 if !get(g:, 'fall_disable_default_mapping')
   function! s:define(lhs, rhs) abort
-    if !hasmapto(a:rhs, 'c') && empty(maparg(a:lhs, 'c'))
-      execute 'cnoremap <silent> <nowait> ' . a:lhs . ' ' . a:rhs
-    endif
+    execute 'cnoremap <silent> <nowait> ' .. a:lhs .. ' ' .. a:rhs
   endfunction
 
   function! s:map_picker() abort


### PR DESCRIPTION
If we check whether the LHS exists in the mapping, users who remap `<C-n>` to something like `<Up>` would not have Fall’s default mappings defined, making it very inconvenient to use. Additionally, rather than checking if the RHS is already registered, we can allow users to define their mappings after the default mappings by setting the timing accordingly. This way, users can remove default mappings using `<Nop>`. Therefore, I modified the specification to add internal events such as `~System` to enforce the timing.