### PR TITLE
:bug: Cursor line may not be highlighted

### DIFF
--- a/denops/fall/component/list.ts
+++ b/denops/fall/component/list.ts
@@ -133,7 +133,7 @@ export class ListComponent extends BaseComponent {
     await fn.win_execute(
       denops,
       winid,
-      "setlocal cursorline signcolumn=yes nowrap nolist nofoldenable nonumber norelativenumber filetype=fall-list",
+      "setlocal cursorline cursorlineopt=line signcolumn=yes nowrap nolist nofoldenable nonumber norelativenumber filetype=fall-list",
     );
 
     signal?.throwIfAborted();

--- a/denops/fall/component/preview.ts
+++ b/denops/fall/component/preview.ts
@@ -164,7 +164,7 @@ export class PreviewComponent extends BaseComponent {
       await fn.win_execute(
         denops,
         winid,
-        `silent! setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nomodifiable nowrap cursorline`,
+        `silent! setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nomodifiable nowrap cursorline cursorlineopt=number,line`,
       );
       // Move cursor
       await fn.win_execute(


### PR DESCRIPTION
Fix the cursor line is not highlighted when neither `line` and `screenline` are not set to `cursorlineopt`.
This PR makes the window-local option `cursorlineopt` surely have `line` value for the fall.vim windows.

- before:
<img width="763" alt="image.png" src="https://github.com/user-attachments/assets/dec328a6-f11d-424e-b6d5-5b4248ec0326" />

- after:
<img width="878" alt="image" src="https://github.com/user-attachments/assets/956aacb2-2a95-42b6-a226-7171777ed289" />

**Reproduce Steps**

- Prepare this `vimrc.vim`

```vim
set nocompatible

" Please modify these runtimepath value
set runtimepath^=~/.cache/vim/pack/minpac/opt/denops.vim/
set runtimepath^=~/.cache/vim/pack/minpac/opt/fall.vim/

set cursorlineopt=number
let g:fall_custom_path = '/tmp/notfound.vim'
```

- Run vim by `vim -u vimrc.vim`
- Start fall.vim by `:Fall help`
- Check the highlights for the cursor line

**Environment**

- macOS Sequoia
- wezterm 20240203-110809-5046fc22
- Vim 9.1.1113
- deno

```
deno 2.1.10 (stable, release, aarch64-apple-darwin)
v8 13.0.245.12-rusty
typescript 5.6.2
```