### PR TITLE
feat: Decrease default threshold to 10,000

### DIFF
--- a/denops/fall/processor/collect.ts
+++ b/denops/fall/processor/collect.ts
@@ -7,7 +7,7 @@ import type { CollectParams, Source } from "jsr:@vim-fall/core@^0.3.0/source";
 import { Chunker } from "../lib/chunker.ts";
 import { dispatch } from "../event.ts";
 
-const THRESHOLD = 100000;
+const THRESHOLD = 10000;
 const CHUNK_SIZE = 1000;
 
 export type CollectProcessorOptions = {

--- a/denops/fall/processor/match.ts
+++ b/denops/fall/processor/match.ts
@@ -9,7 +9,7 @@ import { ItemBelt } from "../lib/item_belt.ts";
 import { dispatch } from "../event.ts";
 
 const INTERVAL = 0;
-const THRESHOLD = 100000;
+const THRESHOLD = 10000;
 const CHUNK_SIZE = 1000;
 
 export type MatchProcessorOptions = {


### PR DESCRIPTION
It seems 100,000 is too large for some environment and we human cannot handle such a large number of items at once. So, I decrease the default to 10,000 which is still large enough for most cases.