### PR TITLE
fix: Cursor won't be restored on gVim

### DIFF
--- a/autoload/fall/internal/cursor.vim
+++ b/autoload/fall/internal/cursor.vim
@@ -28,6 +28,7 @@ if has('nvim-0.5.0')
   augroup END
 elseif has('nvim') || has('gui_running')
   function! s:hide_cursor() abort
+    let s:guicursor_saved = &guicursor
     set guicursor+=a:ver1
   endfunction
 


### PR DESCRIPTION
On MacVim (must also on gVim, I can't check now though), the cursor disappears after using fall.vim.  This PR fixes it.

### Checked Environment
- macOS Sequoia
- MacVim 9.1.1251

### Reproduce Steps

- Prepare this `vimrc.vim`

```vim
set nocompatible

" Please modify these runtimepath value
set runtimepath^=~/.cache/vim/pack/minpac/opt/denops.vim/
set runtimepath^=~/.cache/vim/pack/minpac/opt/fall.vim/

let g:fall_custom_path = '/tmp/notfound.vim'
```

- Launch gVim(MacVim) with `gvim -u vimrc.vim`
    - Maybe you can use `/Applications/MacVim.app/Contents/bin/mvim -u vimrc.vim`
- Check the cursor exists
- Run fall.vim, e.g. `:Fall file`, and then quit it
- The cursor is still hidden