### PR TITLE
feat: increase default threshold to 100,000

### DIFF
--- a/denops/fall/processor/collect.ts
+++ b/denops/fall/processor/collect.ts
@@ -7,7 +7,7 @@ import type { CollectParams, Source } from "jsr:@vim-fall/core@^0.3.0/source";
 import { Chunker } from "../lib/chunker.ts";
 import { dispatch } from "../event.ts";
 
-const THRESHOLD = 10000;
+const THRESHOLD = 100000;
 const CHUNK_SIZE = 1000;
 
 export type CollectProcessorOptions = {

--- a/denops/fall/processor/match.ts
+++ b/denops/fall/processor/match.ts
@@ -9,7 +9,7 @@ import { ItemBelt } from "../lib/item_belt.ts";
 import { dispatch } from "../event.ts";
 
 const INTERVAL = 0;
-const THRESHOLD = 10000;
+const THRESHOLD = 100000;
 const CHUNK_SIZE = 1000;
 
 export type MatchProcessorOptions = {


### PR DESCRIPTION
The number of helptag seems more than 10,000 so it should be larger than that.