### PR TITLE
Rename FallListSelected sign group to FallListSelectedSign

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Perform pre-cache
         run: |
           deno cache \
+            --config ${DENOPS_TEST_DENOPS_PATH}/denops/@denops-private/deno.jsonc \
             ${DENOPS_TEST_DENOPS_PATH}/denops/@denops-private/mod.ts ./denops/fall/main.ts
 
       - name: Test

--- a/denops/fall/component/list.ts
+++ b/denops/fall/component/list.ts
@@ -8,8 +8,8 @@ import type { Dimension } from "jsr:@vim-fall/core@^0.3.0/coordinator";
 import { BaseComponent, ComponentProperties } from "./_component.ts";
 
 export const HIGHLIGHT_MATCH = "FallListMatch";
-export const SIGN_GROUP_SELECTED = "PopUpFallListSelected";
-export const SIGN_SELECTED = "FallListSelected";
+export const SIGN_GROUP_SELECTED = "PopUpFallListSelectedSign";
+export const SIGN_SELECTED = "FallListSelectedSign";
 
 /**
  * Type representing the decoration properties of an item,

--- a/doc/fall.txt
+++ b/doc/fall.txt
@@ -187,13 +187,13 @@ For example:
 -------------------------------------------------------------------------------
 SIGN				*fall-configuration-sign*
 
-Use FallXXXXX sign groups to configure the picker window appearance. See
+Use FallXXXXXSign sign groups to configure the picker window appearance. See
 |fall-sign| for a list of available sign groups.
 
 For example:
 >vim
 	function! s:my_fall_style() abort
-	  sign define FallListSelected text=*
+	  sign define FallListSelectedSign text=*
 	endfunction
 
 	augroup fall_plugin_style
@@ -643,7 +643,7 @@ HIGHLIGHT					*fall-highlight*
 -----------------------------------------------------------------------------
 SIGN						*fall-sign*
 
-*FallListSelected*
+*FallListSelectedSign*
 	Indicator sign for the selected item in the list component.
 	Default to "»".
 

--- a/plugin/fall/highlight.vim
+++ b/plugin/fall/highlight.vim
@@ -20,7 +20,7 @@ function! s:init() abort
   " List
   highlight default link FallListMatch Search
   highlight default link FallListSelected CurSearch
-  sign define FallListSelected text=≫
+  sign define FallListSelectedSign text=≫
 
   " Help
   highlight default link FallHelpHeader Conceal


### PR DESCRIPTION
## Summary
This PR renames the sign group from `FallListSelected` to `FallListSelectedSign` for consistency with naming conventions.

## Changes
- Renamed `SIGN_GROUP_SELECTED` constant from `PopUpFallListSelected` to `PopUpFallListSelectedSign`
- Renamed `SIGN_SELECTED` constant from `FallListSelected` to `FallListSelectedSign`
- Updated documentation to reflect the new sign group name
- Updated the sign definition in the highlight setup

🤖 Generated with [Claude Code](https://claude.ai/code)